### PR TITLE
Hotfix: Remove duplicate filterGroups declaration

### DIFF
--- a/front-end/src/pages/joinGroup.jsx
+++ b/front-end/src/pages/joinGroup.jsx
@@ -27,18 +27,6 @@ export default function JoinGroupPage() {
 				group.description.toLowerCase().includes(query),
 		);
 	};
-	// Filter function
-	const filterGroups = (groups) => {
-		if (!searchQuery.trim()) return groups;
-
-		const query = searchQuery.toLowerCase();
-		return groups.filter(
-			(group) =>
-				group.name.toLowerCase().includes(query) ||
-				group.by.toLowerCase().includes(query) ||
-				group.description.toLowerCase().includes(query),
-		);
-	};
 
 	const filteredInvites = filterGroups(invites);
 


### PR DESCRIPTION
The app cannot run due to erroring out on multiple declarations.